### PR TITLE
Display lease address in side bar

### DIFF
--- a/templates/sidebar/case-sidebar.html.twig
+++ b/templates/sidebar/case-sidebar.html.twig
@@ -18,7 +18,7 @@
             {% block sidebarSubmenu %}
                 <div class="sidebar-sticky pt-3">
                     <h6 class="px-3 mb-1">{% trans %}Case{% endtrans %} {{ case.caseNumber }}</h6>
-                    <p class="text-muted px-3 mt-1 mb-3"><small>{{ case.leaseAddress }}</small></p>
+                    <p class="text-muted px-3 mt-1 mb-3"><small>{{ attribute(case, 'getLeaseAddress') is defined ? case.leaseAddress : case.complainantAddress }}</small></p>
                     <ul class="nav flex-column">
                         {{ render(controller(
                             'App\\Controller\\SidebarController::renderCaseSubmenu', {

--- a/templates/sidebar/case-sidebar.html.twig
+++ b/templates/sidebar/case-sidebar.html.twig
@@ -18,7 +18,7 @@
             {% block sidebarSubmenu %}
                 <div class="sidebar-sticky pt-3">
                     <h6 class="px-3 mb-1">{% trans %}Case{% endtrans %} {{ case.caseNumber }}</h6>
-                    <p class="text-muted px-3 mt-1 mb-3"><small>{{ attribute(case, 'getLeaseAddress') is defined ? case.leaseAddress : case.complainantAddress }}</small></p>
+                    <p class="text-muted px-3 mt-1 mb-3"><small>{{ case.leaseAddress|default(case.complainantAddress) }}</small></p>
                     <ul class="nav flex-column">
                         {{ render(controller(
                             'App\\Controller\\SidebarController::renderCaseSubmenu', {

--- a/templates/sidebar/case-sidebar.html.twig
+++ b/templates/sidebar/case-sidebar.html.twig
@@ -18,7 +18,7 @@
             {% block sidebarSubmenu %}
                 <div class="sidebar-sticky pt-3">
                     <h6 class="px-3 mb-1">{% trans %}Case{% endtrans %} {{ case.caseNumber }}</h6>
-                    <p class="text-muted px-3 mt-1 mb-3"><small>{{ case.complainantAddress }}</small></p>
+                    <p class="text-muted px-3 mt-1 mb-3"><small>{{ case.leaseAddress }}</small></p>
                     <ul class="nav flex-column">
                         {{ render(controller(
                             'App\\Controller\\SidebarController::renderCaseSubmenu', {


### PR DESCRIPTION
* Displays `leaseAddress` rather than `complainantAddress` for `ResidentComplaintBoardCase` and `RentBoardCase`