### PR TITLE
TVIST1-556: Update labels on case and party forms

### DIFF
--- a/src/Form/FenceReviewCaseType.php
+++ b/src/Form/FenceReviewCaseType.php
@@ -41,7 +41,7 @@ class FenceReviewCaseType extends AbstractType
 
         $builder
             ->add('bringerIdentification', IdentificationType::class, [
-                'label' => false,
+                'label' => $this->translator->trans('Bringer', [], 'case'),
             ])
             ->add('lookupIdentifier', ButtonType::class, [
                 'label' => $this->translator->trans('Find information from identifier', [], 'case'),
@@ -55,7 +55,7 @@ class FenceReviewCaseType extends AbstractType
                 'required' => false,
             ])
             ->add('bringer', TextType::class, [
-                'label' => $this->translator->trans('Bringer', [], 'case'),
+                'label' => $this->translator->trans('Bringer name', [], 'case'),
             ])
             ->add('bringerAddress', AddressLookupType::class, [
                 'label' => $this->translator->trans('Bringer address', [], 'case'),
@@ -66,7 +66,7 @@ class FenceReviewCaseType extends AbstractType
                 'label' => $this->translator->trans('Bringer cadastral number', [], 'case'),
             ])
             ->add('accusedIdentification', IdentificationType::class, [
-                'label' => false,
+                'label' => $this->translator->trans('Accused', [], 'case'),
             ])
             ->add('lookupAccusedIdentifier', ButtonType::class, [
                 'label' => $this->translator->trans('Find information from identifier', [], 'case'),
@@ -80,7 +80,7 @@ class FenceReviewCaseType extends AbstractType
                 'required' => false,
             ])
             ->add('accused', TextType::class, [
-                'label' => $this->translator->trans('Accused', [], 'case'),
+                'label' => $this->translator->trans('Accused name', [], 'case'),
             ])
             ->add('accusedAddress', AddressLookupType::class, [
                 'label' => $this->translator->trans('Accused address', [], 'case'),

--- a/src/Form/PartyFormType.php
+++ b/src/Form/PartyFormType.php
@@ -49,7 +49,7 @@ class PartyFormType extends AbstractType
 
         $builder
             ->add('identification', IdentificationType::class, [
-                'label' => false,
+                'label' => $this->translator->trans('Party', [], 'case'),
                 'constraints' => [
                     new PartyIdentification(),
                 ],

--- a/src/Form/RentBoardCaseType.php
+++ b/src/Form/RentBoardCaseType.php
@@ -41,7 +41,7 @@ class RentBoardCaseType extends AbstractType
 
         $builder
             ->add('bringerIdentification', IdentificationType::class, [
-                'label' => false,
+                'label' => $this->translator->trans('Bringer', [], 'case'),
             ])
             ->add('lookupIdentifier', ButtonType::class, [
                 'label' => $this->translator->trans('Find information from identifier', [], 'case'),
@@ -55,7 +55,7 @@ class RentBoardCaseType extends AbstractType
                 'required' => false,
             ])
             ->add('bringer', TextType::class, [
-                'label' => $this->translator->trans('Bringer', [], 'case'),
+                'label' => $this->translator->trans('Bringer name', [], 'case'),
             ])
             ->add('bringerPhone', IntegerType::class, [
                 'label' => $this->translator->trans('Bringer phone', [], 'case'),

--- a/src/Form/ResidentComplaintBoardCaseType.php
+++ b/src/Form/ResidentComplaintBoardCaseType.php
@@ -41,7 +41,7 @@ class ResidentComplaintBoardCaseType extends AbstractType
 
         $builder
             ->add('bringerIdentification', IdentificationType::class, [
-                'label' => false,
+                'label' => $this->translator->trans('Bringer', [], 'case'),
             ])
             ->add('lookupIdentifier', ButtonType::class, [
                 'label' => $this->translator->trans('Find information from identifier', [], 'case'),
@@ -55,7 +55,7 @@ class ResidentComplaintBoardCaseType extends AbstractType
                 'required' => false,
             ])
             ->add('bringer', TextType::class, [
-                'label' => $this->translator->trans('Bringer', [], 'case'),
+                'label' => $this->translator->trans('Bringer name', [], 'case'),
             ])
             ->add('bringerPhone', IntegerType::class, [
                 'label' => $this->translator->trans('Bringer phone', [], 'case'),

--- a/templates/form/theme.html.twig
+++ b/templates/form/theme.html.twig
@@ -3,7 +3,6 @@
 
 {% block identification_widget %}
     <div {{ block('widget_container_attributes') }}>
-        {{ form_label(form.identifier) }}
         <div class="input-group mb-3">
             <div class="input-group-prepend">
                 {{ form_widget(form.type) }}

--- a/templates/party/add.html.twig
+++ b/templates/party/add.html.twig
@@ -25,7 +25,7 @@
         {{ form_start(add_party_form) }}
         {{ form_errors(add_party_form) }}
         <div class="form-row">
-            <div class="col-md-6 mb-3">
+            <div class="col-md-12 mb-3">
                 {{ form_row(add_party_form.identification) }}
             </div>
         </div>

--- a/translations/case+intl-icu.da.xlf
+++ b/translations/case+intl-icu.da.xlf
@@ -1279,7 +1279,7 @@
       </trans-unit>
       <trans-unit id="BxXUyin" resname="Bringer address">
         <source>Bringer address</source>
-        <target state="translated">Adresse</target>
+        <target state="translated">Indbringers adresse</target>
       </trans-unit>
       <trans-unit id="uAn2V7I" resname="Look up bringer address">
         <source>Look up bringer address</source>
@@ -1295,7 +1295,7 @@
       </trans-unit>
       <trans-unit id="R5dtr4F" resname="Bringer phone">
         <source>Bringer phone</source>
-        <target state="translated">Telefonnummer</target>
+        <target state="translated">Indbringers telefonnummer</target>
       </trans-unit>
       <trans-unit id="Jyn13Ug" resname="Parties">
         <source>Parties</source>
@@ -1303,7 +1303,7 @@
       </trans-unit>
       <trans-unit id="sT9BRdo" resname="Bringer name">
         <source>Bringer name</source>
-        <target state="translated">Navn</target>
+        <target state="translated">Indbringers navn</target>
       </trans-unit>
       <trans-unit id="VXVbSna" resname="A case must have both a party and a counter part before entering the hearing phase.">
         <source>A case must have both a party and a counter part before entering the hearing phase.</source>
@@ -1460,6 +1460,14 @@
       <trans-unit id="hxJPdUw" resname="Reminder updated">
         <source>Reminder updated</source>
         <target state="translated">Påmindelse opdateret</target>
+      </trans-unit>
+      <trans-unit id="ENS2QDD" resname="Accused name">
+        <source>Accused name</source>
+        <target state="translated">Modparts navn</target>
+      </trans-unit>
+      <trans-unit id="36gvIbP" resname="Party">
+        <source>Party</source>
+        <target state="translated">Part</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/case+intl-icu.en.xlf
+++ b/translations/case+intl-icu.en.xlf
@@ -1465,6 +1465,14 @@
         <source>Reminder updated</source>
         <target>Reminder updated</target>
       </trans-unit>
+      <trans-unit id="ENS2QDD" resname="Accused name">
+        <source>Accused name</source>
+        <target>Accused name</target>
+      </trans-unit>
+      <trans-unit id="36gvIbP" resname="Party">
+        <source>Party</source>
+        <target>Party</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
* Updates labels on forms to be more clear

Before 
<img width="660" alt="beforelabels" src="https://user-images.githubusercontent.com/78410897/169278823-e5e39169-d8b9-48df-bd9f-618507fcb575.png">


After
<img width="660" alt="afterlabels" src="https://user-images.githubusercontent.com/78410897/169278855-6fd5be2a-1a5b-4937-8886-3aeced5a6d68.png">



https://jira.itkdev.dk/browse/TVIST1-556