### PR TITLE
Feature/tvist1 592 receipt translations and minor changes

### DIFF
--- a/fixtures/board.yaml
+++ b/fixtures/board.yaml
@@ -46,6 +46,8 @@ App\Entity\Board:
     counterpartyTypes: |-
       Udlejer
       Udlejer administrator
+    receiptCase: '@mail-template-board-receipt-case-001'
+    receiptHearingPost: '@mail-template-board-receipt-hearing_post-001'
 
   rent-board-aarhus:
     name: Huslejenævnet
@@ -69,6 +71,8 @@ App\Entity\Board:
     counterpartyTypes: |-
       Udlejer
       Udlejer administrator
+    receiptCase: '@mail-template-board-receipt-case-001'
+    receiptHearingPost: '@mail-template-board-receipt-hearing_post-001'
 
   rent-board-randers:
     name: Huslejenævnet
@@ -92,6 +96,8 @@ App\Entity\Board:
     counterpartyTypes: |-
       Udlejer
       Udlejer administrator
+    receiptCase: '@mail-template-board-receipt-case-001'
+    receiptHearingPost: '@mail-template-board-receipt-hearing_post-001'
 
   fence-board-aarhus:
     name: Hegnsnævnet
@@ -115,6 +121,8 @@ App\Entity\Board:
     counterpartyTypes: |-
       Nabo
       Nabo repræsentant
+    receiptCase: '@mail-template-board-receipt-case-001'
+    receiptHearingPost: '@mail-template-board-receipt-hearing_post-001'
 
   fence-board-randers:
     name: Hegnsnævnet
@@ -138,3 +146,5 @@ App\Entity\Board:
     counterpartyTypes: |-
       Nabo
       Nabo repræsentant
+    receiptCase: '@mail-template-board-receipt-case-001'
+    receiptHearingPost: '@mail-template-board-receipt-hearing_post-001'

--- a/fixtures/case_entity.yaml
+++ b/fixtures/case_entity.yaml
@@ -1004,3 +1004,4 @@ App\Entity\FenceReviewCase:
     bringerClaim: |
         Claim for this review
     bringerCadastralNumber: 'Mat 11'
+    assignedTo: '@user-caseworker'

--- a/src/Service/DocumentUploader.php
+++ b/src/Service/DocumentUploader.php
@@ -134,4 +134,11 @@ class DocumentUploader
     {
         return filesize($this->getFilepath($document->getFilename()));
     }
+
+    public function getFileContent(Document $document)
+    {
+        $filepath = $this->getFilepath($document->getFilename());
+
+        return file_get_contents($filepath);
+    }
 }

--- a/templates/translations/admin.html.twig
+++ b/templates/translations/admin.html.twig
@@ -80,8 +80,9 @@
     {{ 'Identification'|trans }}
     {{ 'Is under address protection'|trans }}
     {{ 'Custom fields'|trans }}
-
     {{ 'Template document'|trans }}
     {{ 'Upload a Word document (docx) to use as a template.'|trans }}
+    {{ 'Receipt on case'|trans }}
+    {{ 'Receipt on hearing post'|trans }}
 
 {% endblock %}

--- a/translations/admin+intl-icu.en.xlf
+++ b/translations/admin+intl-icu.en.xlf
@@ -349,6 +349,14 @@
         <source>List of custom fields (one per line). Format «name»|«label». Example: full_name|Full name.</source>
         <target>List of custom fields (one per line). Format «name»|«label». Example: full_name|Full name.</target>
       </trans-unit>
+      <trans-unit id="q2LDKij" resname="Receipt on case">
+        <source>Receipt on case</source>
+        <target>Receipt on case</target>
+      </trans-unit>
+      <trans-unit id="V4Dn31Z" resname="Receipt on hearing post">
+        <source>Receipt on hearing post</source>
+        <target>Receipt on hearing post</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/admin.da.xlf
+++ b/translations/admin.da.xlf
@@ -357,6 +357,14 @@
         <source>List of custom fields (one per line). Format «name»|«label». Example: full_name|Full name.</source>
         <target state="translated">Liste af brugerdefinerede flettefelter (en pr. linje). Format «navn»|«label». Eksempel: fulde_navn|Fulde navn.</target>
       </trans-unit>
+      <trans-unit id="q2LDKij" resname="Receipt on case">
+        <source>Receipt on case</source>
+        <target state="translated">Kvittering på sag</target>
+      </trans-unit>
+      <trans-unit id="V4Dn31Z" resname="Receipt on hearing post">
+        <source>Receipt on hearing post</source>
+        <target state="translated">Kvittering på høringssvar</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
https://jira.itkdev.dk/browse/TVIST1-592

* Reintroduces `DocumentUploader` method `getFileContent` which is used in `DigitalPostSendCommand.php`.
* Configures receipt templates in board fixtures.
* Adds missing translations
