### PR TITLE
TVIST1-604: Removed twig timezone configuration

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -10,4 +10,8 @@ twig:
 
     date:
       format: 'd/m/Y H:i'
-      timezone: Europe/Copenhagen
+      # All times EXCEPT LOG ENTRIES are kept as separate DateTime properties,
+      # meaning when a user sets a startTime to 17:00 we can save it exactly like that in the database,
+      # i.e. saving all times separate from dates means we can ignore timezones.
+      # Log entry exceptions are in templates/case/log.html.twig and templates/case/log_entry_show.html.twig.
+      # timezone: Europe/Copenhagen

--- a/fixtures/agenda_item.yaml
+++ b/fixtures/agenda_item.yaml
@@ -1,8 +1,8 @@
 App\Entity\AgendaCaseItem:
   agenda-case-item1:
     title: Drøftelse af 2021-0001
-    startTime: <(new \DateTime('1970-01-01 17:00'))>
-    endTime: <(new \DateTime('1970-01-01 18:00'))>
+    startTime: <(new \DateTime('1970-01-01 18:00'))>
+    endTime: <(new \DateTime('1970-01-01 19:00'))>
     meetingPoint: Mødelokale M3.8
     inspection: false
     caseEntity: '@test-case-aarhus-1'
@@ -10,8 +10,8 @@ App\Entity\AgendaCaseItem:
 
   agenda-case-item2:
     title: Drøftelse af 2021-0009
-    startTime: <(new \DateTime('1970-01-01 17:00'))>
-    endTime: <(new \DateTime('1970-01-01 18:00'))>
+    startTime: <(new \DateTime('1970-01-01 19:00'))>
+    endTime: <(new \DateTime('1970-01-01 20:00'))>
     meetingPoint: Mødelokale M3.8
     inspection: true
     caseEntity: '@test-case-aarhus-9'
@@ -21,15 +21,15 @@ App\Entity\AgendaManuelItem:
   agenda-manuel-item1:
     title: Opstart
     description: Aftensmad og gennemgang af dagsorden
-    startTime: <(new \DateTime('1970-01-01 16:00'))>
-    endTime: <(new \DateTime('1970-01-01 16:30'))>
+    startTime: <(new \DateTime('1970-01-01 17:00'))>
+    endTime: <(new \DateTime('1970-01-01 17:30'))>
     meetingPoint: Mødelokale M3.8
     agenda: '@agenda-1'
 
   agenda-manuel-item2:
     title: Afslutning
     description: Tak for i dag
-    startTime: <(new \DateTime('1970-01-01 19:00'))>
-    endTime: <(new \DateTime('1970-01-01 19:30'))>
+    startTime: <(new \DateTime('1970-01-01 20:00'))>
+    endTime: <(new \DateTime('1970-01-01 20:30'))>
     meetingPoint: Mødelokale M3.8
     agenda: '@agenda-1'

--- a/templates/case/log.html.twig
+++ b/templates/case/log.html.twig
@@ -27,7 +27,7 @@
                 <tbody>
                 {% for log_entry in log_entries %}
                     <tr>
-                        <td>{{ log_entry.createdAt|date(format_datetime) }}</td>
+                        <td>{{ log_entry.createdAt|date(format_datetime, 'Europe/Copenhagen') }}</td>
                         <td>{{ log_entry.user }}</td>
                         <td>{{ log_entry.action|trans }}</td>
                         <td>

--- a/templates/case/log_entry_show.html.twig
+++ b/templates/case/log_entry_show.html.twig
@@ -81,7 +81,7 @@
 
         <dl>
             <dt>{% trans %}Created at{% endtrans %}</dt>
-            <dd>{{ log_entry.createdAt|date(format_datetime) }}</dd>
+            <dd>{{ log_entry.createdAt|date(format_datetime, 'Europe/Copenhagen') }}</dd>
 
             <dt>{% trans %}Username{% endtrans %}</dt>
             <dd>{{ log_entry.user }}</dd>


### PR DESCRIPTION
https://jira.itkdev.dk/browse/TVIST1-604

* Removes twig `date` filter timezone configuration
* Handles `LogEntry` explicitly as it is only occurrence of a `DateTime` object where both the date and time matters.