### PR TITLE
TVIST1: Fix bringer identification validation

### DIFF
--- a/assets/party/identifier-lookup.js
+++ b/assets/party/identifier-lookup.js
@@ -42,7 +42,12 @@ $(function () {
           $('#party_form_address_side').val(response.side)
           $('#party_form_address_postalCode').val(response.postalCode)
           $('#party_form_address_city').val(response.city)
-          $('#party_form_isUnderAddressProtection').prop('checked', response.isUnderAddressProtection)
+
+          if (typeof response.isUnderAddressProtection === 'boolean') {
+            $('#party_form_isUnderAddressProtection').prop('checked', response.isUnderAddressProtection)
+          } else {
+            $('#party_form_isUnderAddressProtection').prop('checked', false)
+          }
 
           // Indicate that identifier was found
           $($identificationLookupButton).removeClass(function () {

--- a/src/Controller/CaseController.php
+++ b/src/Controller/CaseController.php
@@ -821,9 +821,9 @@ class CaseController extends AbstractController
     }
 
     /**
-     * @Route("/{id}/validate-identifier/{idProperty}/{addressProperty}/{nameProperty}", name="case_validate_identifier", methods={"GET", "POST"})
+     * @Route("/{id}/validate-identifier/{idProperty}/{addressProperty}/{addressProtectionProperty}/{nameProperty}", name="case_validate_identifier", methods={"GET", "POST"})
      */
-    public function validateIdentifier(Request $request, CaseEntity $case, IdentificationHelper $identificationHelper, string $idProperty, string $addressProperty, string $nameProperty, TranslatorInterface $translator, PropertyAccessorInterface $propertyAccessor): Response
+    public function validateIdentifier(Request $request, CaseEntity $case, IdentificationHelper $identificationHelper, string $idProperty, string $addressProperty, string $addressProtectionProperty, string $nameProperty, TranslatorInterface $translator, PropertyAccessorInterface $propertyAccessor): Response
     {
         $this->denyAccessUnlessGranted('edit', $case);
 
@@ -832,7 +832,7 @@ class CaseController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             try {
-                $identificationHelper->validateIdentification($case, $idProperty, $addressProperty, $nameProperty);
+                $identificationHelper->validateIdentification($case, $idProperty, $addressProperty, $addressProtectionProperty, $nameProperty);
 
                 $this->addFlash('success', new TranslatableMessage('Identification validated', [], 'case'));
 
@@ -859,6 +859,7 @@ class CaseController extends AbstractController
             'case' => $case,
             'id_property' => $idProperty,
             'address_property' => $addressProperty,
+            'address_protection_property' => $addressProtectionProperty,
             'name_property' => $nameProperty,
         ]);
     }

--- a/src/Service/CaseManager.php
+++ b/src/Service/CaseManager.php
@@ -143,10 +143,11 @@ class CaseManager implements LoggerAwareInterface
         }
     }
 
-    public function getCaseIdentificationValues(CaseEntity $case, string $addressProperty, string $nameProperty): array
+    public function getCaseIdentificationValues(CaseEntity $case, string $addressProperty, string $nameProperty, string $addressProtectionProperty = null): array
     {
         /** @var Address $address */
         $address = $this->propertyAccessor->getValue($case, $addressProperty);
+        $isUnderAddressProtection = $this->propertyAccessor->getValue($case, $addressProtectionProperty);
         $name = $this->propertyAccessor->getValue($case, $nameProperty);
 
         $data = [];
@@ -157,6 +158,10 @@ class CaseManager implements LoggerAwareInterface
         $data['side'] = $address->getSide() ?? '';
         $data['postalCode'] = $address->getPostalCode();
         $data['city'] = $address->getCity();
+
+        if ($addressProtectionProperty) {
+            $data['isUnderAddressProtection'] = $isUnderAddressProtection;
+        }
 
         return $data;
     }

--- a/src/Service/CprHelper.php
+++ b/src/Service/CprHelper.php
@@ -169,9 +169,9 @@ class CprHelper
      *
      * @throws CprException
      */
-    public function validateCpr(CaseEntity $case, string $idProperty, string $addressProperty, string $nameProperty): bool
+    public function validateCpr(CaseEntity $case, string $idProperty, string $addressProperty, string $addressProtectionProperty, string $nameProperty): bool
     {
-        $caseIdentificationRelevantData = $this->caseManager->getCaseIdentificationValues($case, $addressProperty, $nameProperty);
+        $caseIdentificationRelevantData = $this->caseManager->getCaseIdentificationValues($case, $addressProperty, $nameProperty, $addressProtectionProperty);
 
         // Get CPR data
         /** @var Identification $id */
@@ -180,7 +180,7 @@ class CprHelper
         $cprData = $this->lookupCPR($id->getIdentifier());
         $cprDataArray = json_decode(json_encode($cprData), true);
 
-        $cprIdentificationRelevantData = $this->collectRelevantData($cprDataArray, false);
+        $cprIdentificationRelevantData = $this->collectRelevantData($cprDataArray);
 
         if ($caseIdentificationRelevantData != $cprIdentificationRelevantData) {
             throw new CprException($this->translator->trans('Case data not match CPR data', [], 'case'));
@@ -192,7 +192,7 @@ class CprHelper
         return true;
     }
 
-    public function collectRelevantData(array $data, bool $includeAddressProtection = true): array
+    public function collectRelevantData(array $data): array
     {
         $relevantData = [];
 
@@ -204,10 +204,8 @@ class CprHelper
         $relevantData['postalCode'] = $data['adresse']['aktuelAdresse']['postnummer'];
         $relevantData['city'] = $data['adresse']['aktuelAdresse']['postdistrikt'];
 
-        if ($includeAddressProtection) {
-            // If person is NOT under address protection, 'adressebeskyttelse' is simply an empty array
-            $relevantData['isUnderAddressProtection'] = !empty($data['persondata']['adressebeskyttelse']);
-        }
+        // If person is NOT under address protection, 'adressebeskyttelse' is simply an empty array
+        $relevantData['isUnderAddressProtection'] = !empty($data['persondata']['adressebeskyttelse']);
 
         return $relevantData;
     }

--- a/src/Service/CprHelper.php
+++ b/src/Service/CprHelper.php
@@ -180,7 +180,7 @@ class CprHelper
         $cprData = $this->lookupCPR($id->getIdentifier());
         $cprDataArray = json_decode(json_encode($cprData), true);
 
-        $cprIdentificationRelevantData = $this->collectRelevantData($cprDataArray);
+        $cprIdentificationRelevantData = $this->collectRelevantData($cprDataArray, false);
 
         if ($caseIdentificationRelevantData != $cprIdentificationRelevantData) {
             throw new CprException($this->translator->trans('Case data not match CPR data', [], 'case'));
@@ -192,7 +192,7 @@ class CprHelper
         return true;
     }
 
-    public function collectRelevantData(array $data): array
+    public function collectRelevantData(array $data, bool $includeAddressProtection = true): array
     {
         $relevantData = [];
 
@@ -203,8 +203,11 @@ class CprHelper
         $relevantData['side'] = array_key_exists('sidedoer', $data['adresse']['aktuelAdresse']) ? ltrim($data['adresse']['aktuelAdresse']['sidedoer'], '0') : '';
         $relevantData['postalCode'] = $data['adresse']['aktuelAdresse']['postnummer'];
         $relevantData['city'] = $data['adresse']['aktuelAdresse']['postdistrikt'];
-        // If person is NOT under address protection, 'adressebeskyttelse' is simply an empty array
-        $relevantData['isUnderAddressProtection'] = !empty($data['persondata']['adressebeskyttelse']);
+
+        if ($includeAddressProtection) {
+            // If person is NOT under address protection, 'adressebeskyttelse' is simply an empty array
+            $relevantData['isUnderAddressProtection'] = !empty($data['persondata']['adressebeskyttelse']);
+        }
 
         return $relevantData;
     }

--- a/src/Service/CvrHelper.php
+++ b/src/Service/CvrHelper.php
@@ -126,7 +126,7 @@ class CvrHelper
         $cvrData = $this->lookupCvr($id->getIdentifier());
         $cvrDataArray = json_decode(json_encode($cvrData), true);
 
-        $cvrIdentificationRelevantData = $this->collectRelevantData($cvrDataArray);
+        $cvrIdentificationRelevantData = $this->collectRelevantData($cvrDataArray, false);
 
         if ($caseIdentificationRelevantData != $cvrIdentificationRelevantData) {
             throw new CvrException($this->translator->trans('Case data not match CVR data', [], 'case'));
@@ -138,7 +138,7 @@ class CvrHelper
         return true;
     }
 
-    public function collectRelevantData(array $data): array
+    public function collectRelevantData(array $data, bool $includeAddressProtection = true): array
     {
         $relevantData = [];
 
@@ -149,7 +149,11 @@ class CvrHelper
         $relevantData['side'] = $data['beliggenhedsadresse']['CVRAdresse_doerbetegnelse'] ?? '';
         $relevantData['postalCode'] = $data['beliggenhedsadresse']['CVRAdresse_postnummer'] ?? '';
         $relevantData['city'] = $data['beliggenhedsadresse']['CVRAdresse_postdistrikt'] ?? '';
-        $relevantData['isUnderAddressProtection'] = false;
+
+        if ($includeAddressProtection) {
+            // Business' (Virksomheder) cannot be under address protection.
+            $relevantData['isUnderAddressProtection'] = false;
+        }
 
         return $relevantData;
     }

--- a/src/Service/CvrHelper.php
+++ b/src/Service/CvrHelper.php
@@ -126,7 +126,7 @@ class CvrHelper
         $cvrData = $this->lookupCvr($id->getIdentifier());
         $cvrDataArray = json_decode(json_encode($cvrData), true);
 
-        $cvrIdentificationRelevantData = $this->collectRelevantData($cvrDataArray, false);
+        $cvrIdentificationRelevantData = $this->collectRelevantData($cvrDataArray);
 
         if ($caseIdentificationRelevantData != $cvrIdentificationRelevantData) {
             throw new CvrException($this->translator->trans('Case data not match CVR data', [], 'case'));
@@ -138,7 +138,7 @@ class CvrHelper
         return true;
     }
 
-    public function collectRelevantData(array $data, bool $includeAddressProtection = true): array
+    public function collectRelevantData(array $data): array
     {
         $relevantData = [];
 
@@ -149,11 +149,6 @@ class CvrHelper
         $relevantData['side'] = $data['beliggenhedsadresse']['CVRAdresse_doerbetegnelse'] ?? '';
         $relevantData['postalCode'] = $data['beliggenhedsadresse']['CVRAdresse_postnummer'] ?? '';
         $relevantData['city'] = $data['beliggenhedsadresse']['CVRAdresse_postdistrikt'] ?? '';
-
-        if ($includeAddressProtection) {
-            // Business' (Virksomheder) cannot be under address protection.
-            $relevantData['isUnderAddressProtection'] = false;
-        }
 
         return $relevantData;
     }

--- a/src/Service/IdentificationHelper.php
+++ b/src/Service/IdentificationHelper.php
@@ -25,13 +25,13 @@ class IdentificationHelper implements EventSubscriberInterface
      * @throws CprException
      * @throws CvrException
      */
-    public function validateIdentification(CaseEntity $case, string $idProperty, string $addressProperty, string $nameProperty)
+    public function validateIdentification(CaseEntity $case, string $idProperty, string $addressProperty, string $addressProtectionProperty, string $nameProperty)
     {
         /** @var Identification $identification */
         $identification = $this->propertyAccessor->getValue($case, $idProperty);
 
         if (self::IDENTIFIER_TYPE_CPR === $identification->getType()) {
-            $this->cprHelper->validateCpr($case, $idProperty, $addressProperty, $nameProperty);
+            $this->cprHelper->validateCpr($case, $idProperty, $addressProperty, $addressProtectionProperty, $nameProperty);
         } else {
             $this->cvrHelper->validateCvr($case, $idProperty, $addressProperty, $nameProperty);
         }

--- a/templates/case/_case_show/_resident_and_rent_board_shareds.html.twig
+++ b/templates/case/_case_show/_resident_and_rent_board_shareds.html.twig
@@ -37,7 +37,7 @@
                             <input type="text" class="form-control" value="{{ case.bringerPhone }}" readonly>
                         </div>
                         {% if is_granted('ROLE_CASEWORKER') or is_granted('ROLE_ADMINISTRATION') %}
-                            {% include 'case/_identifier.html.twig' with {case: case, id_property: 'bringerIdentification', address_property: 'bringerAddress', name_property: 'bringer'} %}
+                            {% include 'case/_identifier.html.twig' with {case: case, id_property: 'bringerIdentification', address_property: 'bringerAddress', address_protection_property: 'bringerIsUnderAddressProtection', name_property: 'bringer'} %}
                         {% endif %}
                     </div>
 

--- a/templates/case/_case_show/fence_review_case.html.twig
+++ b/templates/case/_case_show/fence_review_case.html.twig
@@ -36,7 +36,7 @@
                                 <input type="text" class="form-control" id="inputBasicInformation1" value="{{ case.bringer }}" readonly>
                             </div>
                             {% if is_granted('ROLE_CASEWORKER') or is_granted('ROLE_ADMINISTRATION') %}
-                                {% include 'case/_identifier.html.twig' with {case: case, id_property: 'bringerIdentification', address_property: 'bringerAddress', name_property: 'bringer'} %}
+                                {% include 'case/_identifier.html.twig' with {case: case, id_property: 'bringerIdentification', address_property: 'bringerAddress', address_protection_property: 'bringerIsUnderAddressProtection', name_property: 'bringer'} %}
                             {% endif %}
                         </div>
 
@@ -59,7 +59,7 @@
                                 <input type="text" class="form-control" id="inputBasicInformation3" value="{{ case.accused }}" readonly>
                             </div>
                             {% if is_granted('ROLE_CASEWORKER') or is_granted('ROLE_ADMINISTRATION') %}
-                                {% include 'case/_identifier.html.twig' with {case: case, id_property: 'accusedIdentification', address_property: 'accusedAddress', name_property: 'accused'} %}
+                                {% include 'case/_identifier.html.twig' with {case: case, id_property: 'accusedIdentification', address_property: 'accusedAddress', address_protection_property: 'accusedIsUnderAddressProtection', name_property: 'accused'} %}
                             {% endif %}
                         </div>
 

--- a/templates/case/_identifier.html.twig
+++ b/templates/case/_identifier.html.twig
@@ -27,7 +27,7 @@
         {% if id.validatedAt %}
             <span class="btn btn-block btn-success" type="button" data-toggle="tooltip" data-placement="auto" title="{{ 'Identification validated at {validation_time}'|trans({'validation_time': id.validatedAt|date(format_datetime)}) }}"><i class="fas fa-check-circle"></i> {% trans with {type: id.type} %}Identifier ({type}) validated{% endtrans %}</span>
         {% else %}
-            {{ render(controller('App\\Controller\\CaseController:validateIdentifier', {id: case.id, idProperty: id_property, addressProperty: address_property, nameProperty: name_property})) }}
+            {{ render(controller('App\\Controller\\CaseController:validateIdentifier', {id: case.id, idProperty: id_property, addressProperty: address_property, addressProtectionProperty: address_protection_property, nameProperty: name_property})) }}
         {% endif %}
     </div>
 {% else %}

--- a/templates/case/_validate_identifier.html.twig
+++ b/templates/case/_validate_identifier.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain 'case' %}
 
-{{ form_start(form, {'action': path('case_validate_identifier', {id: case.id, idProperty: id_property, addressProperty: address_property, nameProperty: name_property}), 'attr': {'data-use-ajax': true}}) }}
+{{ form_start(form, {'action': path('case_validate_identifier', {id: case.id, idProperty: id_property, addressProperty: address_property, addressProtectionProperty: address_protection_property, nameProperty: name_property}), 'attr': {'data-use-ajax': true}}) }}
     {% set identifier_type = attribute(case, id_property).type %}
     {# twigcs use-var identifier_type #}
     <div class="form-header">


### PR DESCRIPTION
~~Only case parties contain address protection information. I.e. when validating case bringer we should not include the address protection value in data comparison between CPR/CVR register and case data.~~

We do in fact have address protection on bringer/accused. We should just not consider it when dealing with businesses as they cannot be under address protection.