### PR TITLE
TVIST1-670: Updated agenda.items macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ MunicipalityListener, BoardListener and their tests.
 ### Changed
 - [NSEK-138](https://jira.itkdev.dk/browse/NSEK-138): Updating Cypress to 6.5.0 so the same version is used project wide.
 - [TVIST1-144](https://jira.itkdev.dk/browse/TVIST1-144): Switched to `itk-dev/openid-connect-bundle` for AD and CLI login.
+- [TVIST1-670](https://jira.itkdev.dk/browse/TVIST1-670): Updated `${agenda.items}` template macro.
 
 ### Fixed
 - [NSEK-104](https://jira.itkdev.dk/browse/NSEK-104): Added missing database variables to .env file.

--- a/src/Service/MailTemplate/ComplexMacroHelper.php
+++ b/src/Service/MailTemplate/ComplexMacroHelper.php
@@ -107,20 +107,43 @@ class ComplexMacroHelper
 
         // Agenda items
         $table = new Table([
-            'unit' => TblWidth::TWIP,
+            // @see https://github.com/PHPOffice/PHPWord/blob/develop/src/PhpWord/SimpleType/TblWidth.php#L36
+            //Width in Fiftieths of a Percent
+            'unit' => TblWidth::PERCENT,
             'cellMargin' => 0,
             'spacing' => 0,
+            'width' => 100 * 50,
         ]);
 
+        $count = 1;
         foreach ($agenda->getAgendaItems() as $agendaItem) {
-            $this->addTableRow($table, [
-                sprintf('%s–%s',
-                    $agendaItem->getStartTime()->format('H:i'),
-                    $agendaItem->getEndTime()->format('H:i')
-                ),
+            $text = $agendaItem->getMeetingPoint() ? sprintf('%s–%s > %s, %s',
+                $agendaItem->getStartTime()->format('H:i'),
+                $agendaItem->getEndTime()->format('H:i'),
                 $agendaItem->getTitle(),
                 $agendaItem->getMeetingPoint(),
+            ) : sprintf('%s–%s > %s',
+                $agendaItem->getStartTime()->format('H:i'),
+                $agendaItem->getEndTime()->format('H:i'),
+                $agendaItem->getTitle(),
+            );
+
+            $this->addTableRow($table, [
+                [
+                    'text' => (string) $count,
+                    'cell' => [
+                        'width' => 5 * 50,
+                    ],
+                ],
+                [
+                    'text' => $text,
+                    'cell' => [
+                        'width' => 95 * 50,
+                    ],
+                ],
             ]);
+
+            ++$count;
         }
 
         $values['agenda.items'] = new ComplexMacro($table, 'Agenda items');

--- a/src/Service/MailTemplate/ComplexMacroHelper.php
+++ b/src/Service/MailTemplate/ComplexMacroHelper.php
@@ -12,6 +12,7 @@ use PhpOffice\PhpWord\Element\Link;
 use PhpOffice\PhpWord\Element\Row;
 use PhpOffice\PhpWord\Element\Table;
 use PhpOffice\PhpWord\Element\TextRun;
+use PhpOffice\PhpWord\SimpleType\Jc;
 use PhpOffice\PhpWord\SimpleType\TblWidth;
 use PhpOffice\PhpWord\Style\Font;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -117,20 +118,21 @@ class ComplexMacroHelper
 
         $count = 1;
         foreach ($agenda->getAgendaItems() as $agendaItem) {
-            $text = $agendaItem->getMeetingPoint() ? sprintf('%s–%s > %s, %s',
+            $text =
+                sprintf('%s–%s &lt; %s',
                 $agendaItem->getStartTime()->format('H:i'),
                 $agendaItem->getEndTime()->format('H:i'),
                 $agendaItem->getTitle(),
-                $agendaItem->getMeetingPoint(),
-            ) : sprintf('%s–%s > %s',
-                $agendaItem->getStartTime()->format('H:i'),
-                $agendaItem->getEndTime()->format('H:i'),
-                $agendaItem->getTitle(),
-            );
+            )
+            ;
+
+            if ($agendaItem->getMeetingPoint()) {
+                $text .= sprintf(', %s', $agendaItem->getMeetingPoint());
+            }
 
             $this->addTableRow($table, [
                 [
-                    'text' => (string) $count,
+                    'text' => $count.'.',
                     'cell' => [
                         'width' => 5 * 50,
                     ],


### PR DESCRIPTION
https://jira.itkdev.dk/browse/TVIST1-670

* Changes the layout of the table generated by PHPWord on `agenda.items` macro
* Adds a counter to agenda items on `agenda.items` macro

Before
<img width="631" alt="Screenshot 2022-10-10 at 09 17 06" src="https://user-images.githubusercontent.com/78410897/194815271-2f2ab7a9-38b7-43a7-899a-b55f9c087ebf.png">

After
<img width="631" alt="Screenshot 2022-10-10 at 09 16 47" src="https://user-images.githubusercontent.com/78410897/194815317-1e09a3b5-c751-4b9f-bfe7-d44630cb0108.png">

