### PR TITLE
TVIST1-786: Handled digital post maximum subject length

### DIFF
--- a/fixtures/digital_post.yml
+++ b/fixtures/digital_post.yml
@@ -18,6 +18,12 @@ App\Entity\DigitalPost:
         entityId: '@agenda-1->id'
         subject: 'Agenda Broadcast'
 
+    digital-post-004:
+        document: '@document-001'
+        entityType: 'App\Entity\ResidentComplaintBoardCase'
+        entityId: '@test-case-aarhus-1->id'
+        subject: 'Digital post with a very long subject'
+
 App\Entity\DigitalPostAttachment:
     digital-post-attachment-001:
         digitalPost: '@digital-post-001'

--- a/src/Command/DigitalPostListCommand.php
+++ b/src/Command/DigitalPostListCommand.php
@@ -61,6 +61,7 @@ class DigitalPostListCommand extends Command
             $io->definitionList(
                 ['Id' => $digitalPost->getId()],
                 ['Subject' => $digitalPost->getSubject()],
+                ['Subject (truncated)' => $digitalPost->getSubject(true)],
                 ['Status' => $digitalPost->getStatus() ?? self::STATUS_NULL],
                 ['Recipients' => implode(PHP_EOL, $digitalPost->getRecipients()->map(static fn (DigitalPost\Recipient $recipient) => (string) $recipient)->toArray())],
                 ['Created at' => $digitalPost->getCreatedAt()->format(\DateTimeInterface::ATOM)],

--- a/src/Entity/DigitalPost.php
+++ b/src/Entity/DigitalPost.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use App\Entity\DigitalPost\Recipient;
 use App\Repository\DigitalPostRepository;
+use App\Service\DigitalPostHelper;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -266,9 +267,16 @@ class DigitalPost
         }
     }
 
-    public function getSubject(): ?string
+    /**
+     * Get subject.
+     *
+     * @see DigitalPostHelper::SUBJECT_MAX_LENGTH.
+     *
+     * @param bool $truncate If set, the subject will be truncated to the maximum length allowed when actually sending the post
+     */
+    public function getSubject(bool $truncate = false): ?string
     {
-        return $this->subject;
+        return $truncate ? mb_substr($this->subject, 0, DigitalPostHelper::SUBJECT_MAX_LENGTH) : $this->subject;
     }
 
     public function setSubject(string $subject): self

--- a/src/Service/DigitalPostHelper.php
+++ b/src/Service/DigitalPostHelper.php
@@ -17,6 +17,15 @@ use Symfony\Component\Uid\Uuid;
 
 class DigitalPostHelper extends DigitalPost
 {
+    /**
+     * Maximum length of digital post subject.
+     *
+     * It's not obvious, i.e. clearly documented, what the maximum length actually
+     * is, but XSDs embedded in the documentation on
+     * https://digitaliseringskataloget.dk/integration/sf1600 suggest that it's 34.
+     */
+    public const SUBJECT_MAX_LENGTH = 34;
+
     private array $serviceOptions;
 
     public function __construct(private CprHelper $cprHelper, private DocumentUploader $documentUploader, private EntityManagerInterface $entityManager, array $options)
@@ -37,6 +46,8 @@ class DigitalPostHelper extends DigitalPost
     public function sendDigitalPostCPR(string $cpr, string $name, Address $address, string $title, string $content, array $attachments = []): array
     {
         $bilag = $this->buildBilag($attachments);
+
+        $title = mb_substr($title, 0, self::SUBJECT_MAX_LENGTH);
 
         $result = $this->setServiceOptions($this->serviceOptions['digital_post_options'])
             ->afsendBrevPerson(
@@ -74,6 +85,8 @@ class DigitalPostHelper extends DigitalPost
     public function sendDigitalPostCVR(string $cvr, string $name, Address $address, string $title, string $content, array $attachments = []): array
     {
         $bilag = $this->buildBilag($attachments);
+
+        $title = mb_substr($title, 0, self::SUBJECT_MAX_LENGTH);
 
         $result = $this->setServiceOptions($this->serviceOptions['digital_post_options'])
             ->afsendBrevCVR(
@@ -189,7 +202,8 @@ class DigitalPostHelper extends DigitalPost
                 $digitalPost->setPrevious($digitalPosts[$index - 1]);
             }
             if ($numberOfDigitalPosts > 1) {
-                $newSubject = sprintf('%s (%d/%d)', $digitalPost->getSubject(), $index + 1, $numberOfDigitalPosts);
+                // The subject will be truncated to at most self::SUBJECT_MAX_LENGTH characters so we prefix with the counter.
+                $newSubject = sprintf('(%2$d/%3$d) %1$s', $digitalPost->getSubject(), $index + 1, $numberOfDigitalPosts);
                 $digitalPost->setSubject($newSubject);
             }
 

--- a/templates/case/communication/digital_post/index.html.twig
+++ b/templates/case/communication/digital_post/index.html.twig
@@ -29,7 +29,11 @@
             {% for digital_post in digital_posts %}
                 <tr>
                     <td>{{ digital_post.createdAt ? digital_post.createdAt|date(format_datetime) : '' }}</td>
-                    <td>{{ digital_post.subject }}</td>
+                    <td>{{ digital_post.subject(true) }}
+                        {% if digital_post.subject(true) != digital_post.subject %}
+                            ({{ 'truncated'|trans }})
+                        {% endif %}
+                    </td>
                     <td>{{ digital_post.status ?? '–' }}</td>
                     <td>{{ digital_post.sentAt ? digital_post.sentAt|date(format_datetime) : '–' }}</td>
                     <td>{{ digital_post.document.documentName }}</td>

--- a/templates/case/communication/digital_post/show.html.twig
+++ b/templates/case/communication/digital_post/show.html.twig
@@ -28,7 +28,11 @@
             <dd class="col-sm-9">{{ digital_post.createdAt ? digital_post.createdAt|date(format_datetime) : '–' }}</dd>
 
             <dt class="col-sm-3">{% trans %}Subject{% endtrans %}</dt>
-            <dd class="col-sm-9">{{ digital_post.subject }}</dd>
+            <dd class="col-sm-9">{{ digital_post.subject(true) }}
+                {% if digital_post.subject(true) != digital_post.subject %}
+                    ({{ 'truncated'|trans }})
+                {% endif %}
+            </dd>
 
             {% if digital_post.next %}
                 <dt class="col-sm-3">{% trans %}Next{% endtrans %}</dt>

--- a/translations/digital_post+intl-icu.da.xlf
+++ b/translations/digital_post+intl-icu.da.xlf
@@ -73,6 +73,10 @@
         <source>PNR for {boardMember} not found ({cprNumber})</source>
         <target state="translated">Cpr nummer for {boardMember} kunne ikke findes ({cprNumber})</target>
       </trans-unit>
+      <trans-unit id="InscLlP" resname="truncated">
+        <source>truncated</source>
+        <target state="translated">afkortet</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/digital_post+intl-icu.en.xlf
+++ b/translations/digital_post+intl-icu.en.xlf
@@ -73,6 +73,10 @@
         <source>PNR for {boardMember} not found ({cprNumber})</source>
         <target>PNR for {boardMember} not found ({cprNumber})</target>
       </trans-unit>
+      <trans-unit id="InscLlP" resname="truncated">
+        <source>truncated</source>
+        <target>truncated</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
https://jira.itkdev.dk/browse/TVIST1-786

Handles digital post maximum subject length when displaying and sending digital post (the full subject is still stored in the database).
