### PR TITLE
SUPP0RT-874: Handle invalid custom field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+- [SUPP0RT-874](https://jira.itkdev.dk/browse/SUPP0RT-874)
+  Handled invalid custom field element names.
+
 ## [1.1.1] 2023-02-15
 
 - Bumped digital post max subject length to 50 characters

--- a/fixtures/mail_template.yaml
+++ b/fixtures/mail_template.yaml
@@ -41,6 +41,9 @@ App\Entity\MailTemplate:
     customFields: |-
       some_merge_field1|Some merge field1
       some_merge_field2|Some merge field2
+      description|Description|textarea
+
+      An invalid field name.|An invalid field name|textarea
 
   mail-template-agenda-inspection-001:
     type: agenda_inspection

--- a/src/Controller/Admin/MailTemplateCrudController.php
+++ b/src/Controller/Admin/MailTemplateCrudController.php
@@ -57,8 +57,11 @@ class MailTemplateCrudController extends AbstractCrudController
             ->setChoices($this->mailTemplateHelper->getMailTemplateTypeChoices())
         ;
         yield TextField::new('name');
+
+        // Note: We don't validate the custom field names, but make sure they're
+        // valid when used (cf. MailTemplateHelper::getCustomFields()).
         yield TextareaField::new('customFields', 'Custom fields')
-            ->setHelp($this->translator->trans('List of custom fields (one per line). Format «name»|«label»|«type». Here «type» can be text or textarea. If «type» is omitted or does not match either of the allowed types the input field will be of type text. Example: full_name|Full name|textarea.',
+            ->setHelp($this->translator->trans('List of custom fields (one per line). Format «name»|«label»|«type».<br/>«name» must start with a letter, digit or underscore and only contain letters, digits, numbers, underscores ("_").<br/>«type» can be text or textarea. If «type» is omitted or does not match either of the allowed types the input field will be of type text.<br/>Example: full_name|Full name|textarea.',
                 [], 'admin'))
             // Avoid showing 'Null' or 'Tom' if customFields is not set.
             ->formatValue(function ($value) {

--- a/translations/admin+intl-icu.en.xlf
+++ b/translations/admin+intl-icu.en.xlf
@@ -365,9 +365,9 @@
         <source>KLE</source>
         <target>KLE</target>
       </trans-unit>
-      <trans-unit id="6njiE3P" resname="List of custom fields (one per line). Format «name»|«label»|«type». Here «type» can be text or textarea. If «type» is omitted or does not match either of the allowed types the input field will be of type text. Example: full_name|Full name|textarea.">
-        <source>List of custom fields (one per line). Format «name»|«label»|«type». Here «type» can be text or textarea. If «type» is omitted or does not match either of the allowed types the input field will be of type text. Example: full_name|Full name|textarea.</source>
-        <target>List of custom fields (one per line). Format «name»|«label»|«type». Here «type» can be text or textarea. If «type» is omitted or does not match either of the allowed types the input field will be of type text. Example: full_name|Full name|textarea.</target>
+      <trans-unit id="wRH_Y.w" resname="List of custom fields (one per line). Format «name»|«label»|«type».&lt;br/&gt;«name» must start with a letter, digit or underscore and only contain letters, digits, numbers, underscores (&quot;_&quot;).&lt;br/&gt;«type» can be text or textarea. If «type» is omitted or does not match either of the allowed types the input field will be of type text.&lt;br/&gt;Example: full_name|Full name|textarea.">
+        <source>List of custom fields (one per line). Format «name»|«label»|«type».&lt;br/&gt;«name» must start with a letter, digit or underscore and only contain letters, digits, numbers, underscores ("_").&lt;br/&gt;«type» can be text or textarea. If «type» is omitted or does not match either of the allowed types the input field will be of type text.&lt;br/&gt;Example: full_name|Full name|textarea.</source>
+        <target><![CDATA[List of custom fields (one per line). Format «name»|«label»|«type».<br/>«name» must start with a letter, digit or underscore and only contain letters, digits, numbers, underscores ("_").<br/>«type» can be text or textarea. If «type» is omitted or does not match either of the allowed types the input field will be of type text.<br/>Example: full_name|Full name|textarea.]]></target>
       </trans-unit>
     </body>
   </file>

--- a/translations/admin.da.xlf
+++ b/translations/admin.da.xlf
@@ -377,13 +377,9 @@
         <source>KLE</source>
         <target state="translated">KLE</target>
       </trans-unit>
-      <trans-unit id="Ns4POTg" resname="List of custom fields (one per line). Format «name»|«label»|«type». Here «type» can be text or textArea. If «type» is omitted or does not match either of the allowed types the input field will be of type text. Example: full_name|Full name|textArea.">
-        <source>List of custom fields (one per line). Format «name»|«label»|«type». Here «type» can be text or textArea. If «type» is omitted or does not match either of the allowed types the input field will be of type text. Example: full_name|Full name|textArea.</source>
-        <target state="translated">Liste af brugerdefinerede flettefelter (en pr. linje). Format «navn»|«label»|«type». Her kan «type» være enten text eller textArea. Hvis «type» er udeladt eller ikke matcher en af de tilladte typer vil inputfeltet være af typen text. Eksempel: fulde_navn|Fulde navn|textArea.</target>
-      </trans-unit>
-      <trans-unit id="6njiE3P" resname="List of custom fields (one per line). Format «name»|«label»|«type». Here «type» can be text or textarea. If «type» is omitted or does not match either of the allowed types the input field will be of type text. Example: full_name|Full name|textarea.">
-        <source>List of custom fields (one per line). Format «name»|«label»|«type». Here «type» can be text or textarea. If «type» is omitted or does not match either of the allowed types the input field will be of type text. Example: full_name|Full name|textarea.</source>
-        <target state="translated">Liste af brugerdefinerede flettefelter (en pr. linje). Format «navn»|«label»|«type». Her kan «type» være enten text eller textarea. Hvis «type» er udeladt eller ikke matcher en af de tilladte typer vil inputfeltet være af typen text. Eksempel: fulde_navn|Fulde navn|textarea.</target>
+      <trans-unit id="wRH_Y.w" resname="List of custom fields (one per line). Format «name»|«label»|«type».&lt;br/&gt;«name» must start with a letter, digit or underscore and only contain letters, digits, numbers, underscores (&quot;_&quot;).&lt;br/&gt;«type» can be text or textarea. If «type» is omitted or does not match either of the allowed types the input field will be of type text.&lt;br/&gt;Example: full_name|Full name|textarea.">
+        <source>List of custom fields (one per line). Format «name»|«label»|«type».&lt;br/&gt;«name» must start with a letter, digit or underscore and only contain letters, digits, numbers, underscores ("_").&lt;br/&gt;«type» can be text or textarea. If «type» is omitted or does not match either of the allowed types the input field will be of type text.&lt;br/&gt;Example: full_name|Full name|textarea.</source>
+        <target><![CDATA[Liste af brugerdefinerede flettefelter (ét pr. linje) i formatet «navn»|«label»|«type»<br/>«name» skal starte med et bogstav, tal eller underscore og må kun indeholde bogstaver (a–z), tal og underscores ("_").<br/>«type» være enten text eller textarea. Hvis «type» er udeladt eller ikke matcher en af de tilladte typer vil inputfeltet være af typen text.<br/>Eksempel: fulde_navn|Fulde navn|textarea.]]></target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
https://jira.itkdev.dk/browse/SUPP0RT-874

Handles invalid custom field names.

*Note*: The fields are not validated when defined, but only valid names are used when editing and using the field values.
