### PR TITLE
TVIST1-436: Skipped storing MeMo file content in database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ about writing changes to this log.
 - [TVIST1-436](https://jira.itkdev.dk/browse/TVIST1-436)
   - Removed defunct command and removed digital post status property.
   - Added display of digital post statuses.
+- [TVIST1-436](https://jira.itkdev.dk/browse/TVIST1-436)
+  Skipped storing MeMo file content in database.
 
 ## [1.1.2] 2023-02-17
 

--- a/src/Service/SF1601/DigitalPoster.php
+++ b/src/Service/SF1601/DigitalPoster.php
@@ -70,6 +70,11 @@ class DigitalPoster
             $serializer = new Serializer();
             $receipt = $response->getContent();
 
+            // We don't want to store actual document content in the envelope.
+            $body = $meMoMessage->getMessageBody();
+            $body->getMainDocument()->setFile([]);
+            $body->setAdditionalDocument([]);
+
             $envelope
                 ->setStatus(DigitalPostEnvelope::STATUS_SENT)
                 ->setMessage($serializer->serialize($meMoMessage))


### PR DESCRIPTION
https://jira.itkdev.dk/browse/TVIST1-436

Removes actual file content from MeMo message before storing in database.

