### PR TITLE
TVIST1-755: Custom project docker compose settings in override files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ about writing changes to this log.
   Digital post fixes
 - [TVIST1-755](https://jira.itkdev.dk/browse/TVIST1-755)
   Updated docker compose setup
+- [TVIST1-755](https://jira.itkdev.dk/browse/TVIST1-755)
+  Moved custom project docker compose settings into override files
 
 ## [1.2.0] 2023-03-15
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,29 @@
+services:
+  mariadb:
+    labels:
+      com.symfony.server.service-prefix: 'DATABASE'
+
+  phpfpm:
+    environment:
+      - PHP_MAX_EXECUTION_TIME=60
+      - PHP_MEMORY_LIMIT=512M
+      - PHP_UPLOAD_MAX_FILESIZE=70M
+      # Allow uploading 9 very large files.
+      - PHP_POST_MAX_SIZE=700M
+    depends_on:
+      - libreoffice-api
+
+  libreoffice-api:
+    build: ./.docker/libreoffice-api
+    networks:
+      - app
+    ports:
+      - '9980'
+
+  node:
+    image: node:16
+    networks:
+      - app
+    volumes:
+      - .:/app:delegated
+    working_dir: /app

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -17,8 +17,6 @@ services:
     build: ./.docker/libreoffice-api
     networks:
       - app
-    ports:
-      - '9980'
 
   node:
     image: node:16

--- a/docker-compose.server.override.yml
+++ b/docker-compose.server.override.yml
@@ -1,0 +1,17 @@
+services:
+  phpfpm:
+    environment:
+      - PHP_MAX_EXECUTION_TIME=60
+      - PHP_MEMORY_LIMIT=512M
+      - PHP_UPLOAD_MAX_FILESIZE=70M
+      # Allow uploading 9 very large files.
+      - PHP_POST_MAX_SIZE=700M
+    depends_on:
+      - libreoffice-api
+
+  libreoffice-api:
+    build: ./.docker/libreoffice-api
+    networks:
+      - app
+    ports:
+      - '9980'

--- a/docker-compose.server.override.yml
+++ b/docker-compose.server.override.yml
@@ -13,5 +13,3 @@ services:
     build: ./.docker/libreoffice-api
     networks:
       - app
-    ports:
-      - '9980'

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -20,16 +20,6 @@ services:
       - PHP_MAX_EXECUTION_TIME=30
       - PHP_MEMORY_LIMIT=128M
       - COMPOSER_VERSION=2
-      # Custom project settings start
-      - PHP_MEMORY_LIMIT=256M
-      - PHP_UPLOAD_MAX_FILESIZE=70M
-      # Allow uploading 9 very large files.
-      - PHP_POST_MAX_SIZE=700M
-      # Custom project settings end
-    # Custom project settings start
-    depends_on:
-      - libreoffice-api
-    # Custom project settings end
     volumes:
       - .:/app
 
@@ -56,13 +46,3 @@ services:
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_SERVER_DOMAIN}`)"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.entrypoints=websecure"
-
-  # Custom project settings start
-  libreoffice-api:
-    build: ./.docker/libreoffice-api
-    restart: unless-stopped
-    networks:
-      - app
-    ports:
-      - '9980'
-  # Custom project settings end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,10 +21,6 @@ services:
       - MYSQL_PASSWORD=db
       - MYSQL_DATABASE=db
       #- ENCRYPT=1 # Uncomment to enable database encryption.
-    # Custom project settings start
-    labels:
-      com.symfony.server.service-prefix: 'DATABASE'
-    # Custom project settings end
 
   phpfpm:
     image: itkdev/php8.1-fpm:latest
@@ -38,16 +34,8 @@ services:
       - DOCKER_HOST_DOMAIN=${COMPOSE_DOMAIN}
       - COMPOSER_VERSION=2
       - PHP_IDE_CONFIG=serverName=localhost
-      # Custom project settings start
-      - PHP_UPLOAD_MAX_FILESIZE=70M
-      # Allow uploading 9 very large files.
-      - PHP_POST_MAX_SIZE=700M
-      # Custom project settings end
     depends_on:
       - mariadb
-      # Custom project settings start
-      - libreoffice-api
-      # Custom project settings end
     volumes:
       - .:/app
 
@@ -84,20 +72,3 @@ services:
       - "traefik.docker.network=frontend"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}Mailhog.rule=Host(`mailhog-${COMPOSE_DOMAIN}`)"
       - "traefik.http.services.${COMPOSE_PROJECT_NAME}Mailhog.loadbalancer.server.port=8025"
-
-  # Custom project settings start
-  libreoffice-api:
-    build: ./.docker/libreoffice-api
-    networks:
-      - app
-    ports:
-      - '9980'
-
-  node:
-    image: node:16
-    networks:
-      - app
-    volumes:
-      - .:/app:delegated
-    working_dir: /app
-  # Custom project settings end


### PR DESCRIPTION
Moves custom project docker settings into “override” files (cf. https://docs.docker.com/compose/extends/#adding-and-overriding-configuration).

The “base” files, `docker-compose.server.yml` and `docker-compose.yml`, are exactly the same as the templates in https://github.com/itk-dev/devops_itkdev-docker/tree/develop/templates/symfony-6.

Caveat: We still have a single custom setting in https://github.com/itk-dev/naevnssekretariatet/blob/develop/.docker/vhost.conf#L6-L8 and we/I don't know if we can handle that in a better way.
