### PR TITLE
TVIST1-809: Digital post fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+- [TVIST1-809](https://jira.itkdev.dk/browse/TVIST1-809)
+  Digital post fixes and improvements.
+
 ## [1.3.0] 2023-03-29
 
 - [TVIST1-807](https://jira.itkdev.dk/browse/TVIST1-807)

--- a/migrations/Version20230330110018.php
+++ b/migrations/Version20230330110018.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230330110018 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE digital_post_envelope ADD errors LONGTEXT NOT NULL COMMENT \'(DC2Type:json)\'');
+        $this->addSql('UPDATE digital_post_envelope SET errors = \'[]\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE digital_post_envelope DROP errors');
+    }
+}

--- a/src/Command/DigitalPostEnvelopeListCommand.php
+++ b/src/Command/DigitalPostEnvelopeListCommand.php
@@ -3,6 +3,7 @@
 namespace App\Command;
 
 use App\Entity\CaseDocumentRelation;
+use App\Entity\DigitalPostAttachment;
 use App\Entity\DigitalPostEnvelope;
 use App\Repository\DigitalPostEnvelopeRepository;
 use Doctrine\Common\Collections\Criteria;
@@ -59,6 +60,15 @@ class DigitalPostEnvelopeListCommand extends Command
                 fn (CaseDocumentRelation $relation) => $this->urlGenerator->generate('digital_post_show', ['id' => $relation->getCase()->getId(), 'digitalPost' => $digitalPost->getId()], UrlGeneratorInterface::ABSOLUTE_URL),
                 $digitalPost->getDocument()->getCaseDocumentRelations()->toArray()
             );
+
+            $filenames = array_merge(
+                [$digitalPost->getDocument()->getOriginalFileName()],
+                array_map(
+                    static fn (DigitalPostAttachment $attachment) => $attachment->getDocument()->getOriginalFileName(),
+                    $digitalPost->getAttachments()->toArray()
+                )
+            );
+
             $items = [
                 ['Id' => $envelope->getId()],
                 ['Status' => $envelope->getStatus()],
@@ -69,6 +79,7 @@ class DigitalPostEnvelopeListCommand extends Command
                 ['Updated at' => $envelope->getUpdatedAt()->format(\DateTimeInterface::ATOM)],
                 ['Beskedfordeler message data' => Yaml::dump($data, PHP_INT_MAX)],
                 ['Digital post' => (string) $digitalPost],
+                ['Filenames' => implode(PHP_EOL, $filenames)],
                 ['Digital post URL' => implode(PHP_EOL, $digitalPostUrls)],
             ];
 

--- a/src/Command/DigitalPostEnvelopeListCommand.php
+++ b/src/Command/DigitalPostEnvelopeListCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Yaml\Yaml;
 
 #[AsCommand(
@@ -33,12 +34,18 @@ class DigitalPostEnvelopeListCommand extends Command
             ->addOption('status', null, InputOption::VALUE_REQUIRED, 'Show only envelopes with this status')
             ->addOption('digital-post-subject', null, InputOption::VALUE_REQUIRED, 'Show only envelopes with subject matching this LIKE expression')
             ->addOption('max-results', null, InputOption::VALUE_REQUIRED, 'Show at most this many envelopes', 10)
+            ->addOption('id', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Envelope id')
+            ->addOption('show-throwable', null, InputOption::VALUE_NONE, 'show throwable')
+            ->addOption('show-errors', null, InputOption::VALUE_NONE, 'show errors')
         ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+
+        $showThrowable = $input->getOption('show-throwable');
+        $showErrors = $input->getOption('show-errors');
 
         $envelopes = $this->findEnvelopes($input);
         foreach ($envelopes as $envelope) {
@@ -52,7 +59,8 @@ class DigitalPostEnvelopeListCommand extends Command
                 fn (CaseDocumentRelation $relation) => $this->urlGenerator->generate('digital_post_show', ['id' => $relation->getCase()->getId(), 'digitalPost' => $digitalPost->getId()], UrlGeneratorInterface::ABSOLUTE_URL),
                 $digitalPost->getDocument()->getCaseDocumentRelations()->toArray()
             );
-            $io->definitionList(
+            $items = [
+                ['Id' => $envelope->getId()],
                 ['Status' => $envelope->getStatus()],
                 ['Status message' => $envelope->getStatusMessage()],
                 ['MeMo message uuid' => $envelope->getMeMoMessageUuid()],
@@ -61,8 +69,19 @@ class DigitalPostEnvelopeListCommand extends Command
                 ['Updated at' => $envelope->getUpdatedAt()->format(\DateTimeInterface::ATOM)],
                 ['Beskedfordeler message data' => Yaml::dump($data, PHP_INT_MAX)],
                 ['Digital post' => (string) $digitalPost],
-                ['Digital post URL' => implode(PHP_EOL, $digitalPostUrls)]
-            );
+                ['Digital post URL' => implode(PHP_EOL, $digitalPostUrls)],
+            ];
+
+            if ($showThrowable) {
+                $throwable = unserialize($envelope->getThrowable()) ?: null;
+                $items[] = ['Throwable' => var_export($throwable, true)];
+            }
+
+            if ($showErrors) {
+                $items[] = ['Errors' => var_export($envelope->getErrors(), true)];
+            }
+
+            $io->definitionList(...$items);
         }
 
         return self::SUCCESS;
@@ -80,17 +99,24 @@ class DigitalPostEnvelopeListCommand extends Command
             ->setMaxResults($maxResults)
         ;
 
+        if ($ids = $input->getOption('id')) {
+            $ids = array_map(static fn (string $id) => Uuid::fromString($id)->toBinary(), $ids);
+            $qb
+                ->andWhere('e.id IN (:ids)')
+                ->setParameter('ids', $ids)
+            ;
+        }
         if ($status = $input->getOption('status')) {
             $qb
                 ->andWhere('e.status = :status')
-                ->setParameter(':status', $status)
+                ->setParameter('status', $status)
             ;
         }
         if ($subject = $input->getOption('digital-post-subject')) {
             $qb
                 ->join('e.digitalPost', 'p')
                 ->andWhere('p.subject LIKE :subject')
-                ->setParameter(':subject', $subject)
+                ->setParameter('subject', $subject)
             ;
         }
 

--- a/src/Entity/DigitalPostEnvelope.php
+++ b/src/Entity/DigitalPostEnvelope.php
@@ -103,6 +103,11 @@ class DigitalPostEnvelope
      */
     private array $beskedfordelerMessages = [];
 
+    /**
+     * @ORM\Column(type="json")
+     */
+    private array $errors = [];
+
     public function __construct()
     {
         $this->id = Uuid::v4();
@@ -285,5 +290,21 @@ class DigitalPostEnvelope
     public function getBeskedfordelerMessages(): ?array
     {
         return $this->beskedfordelerMessages;
+    }
+
+    public function addError(string $message, array $context): self
+    {
+        $this->errors[] = [
+            'message' => $message,
+            'context' => $context,
+            'created_at' => (new \DateTimeImmutable())->format(\DateTimeImmutable::ATOM),
+        ];
+
+        return $this;
+    }
+
+    public function getErrors(): ?array
+    {
+        return $this->errors;
     }
 }

--- a/src/Service/SF1601/DigitalPoster.php
+++ b/src/Service/SF1601/DigitalPoster.php
@@ -138,9 +138,11 @@ class DigitalPoster
                     'content' => $response->getContent(false),
                 ];
             }
-            $this->logger->error(sprintf('Error sending digital post: %s', $throwable->getMessage()), $context);
+            $message = sprintf('Error sending digital post: %s', $throwable->getMessage());
+            $this->logger->error($message, $context);
 
             $envelope
+                ->addError($message, $context)
                 ->setStatus(DigitalPostEnvelope::STATUS_FAILED)
                 ->setThrowable($throwable)
             ;

--- a/src/Service/SF1601/DigitalPoster.php
+++ b/src/Service/SF1601/DigitalPoster.php
@@ -79,7 +79,6 @@ class DigitalPoster
                 ForsendelseHelper::FORSENDELSES_TYPE_IDENTIFIKATOR => $this->options['sf1601']['forsendelses_type_identifikator'],
             ];
             $forsendelse = $this->forsendelseHelper->createForsendelse($digitalPost, $recipient, $forsendelseOptions);
-            $forsendelseUuid = $forsendelse->getAfsendelseIdentifikator();
 
             $options = $this->options['sf1601']
                 + [
@@ -103,10 +102,15 @@ class DigitalPoster
                 ->setStatusMessage(null)
                 ->setMeMoMessage($serializer->serialize($meMoMessage))
                 ->setMeMoMessageUuid($messageUuid)
-                ->setForsendelse($serializer->serialize($forsendelse))
-                ->setForsendelseUuid($forsendelseUuid)
                 ->setReceipt($receipt)
             ;
+
+            if (null !== $forsendelse) {
+                $envelope
+                    ->setForsendelse($serializer->serialize($forsendelse))
+                    ->setForsendelseUuid($forsendelse->getAfsendelseIdentifikator())
+                ;
+            }
 
             $this->envelopeRepository->save($envelope, true);
 

--- a/src/Service/SF1601/ForsendelseHelper.php
+++ b/src/Service/SF1601/ForsendelseHelper.php
@@ -4,6 +4,7 @@ namespace App\Service\SF1601;
 
 use App\Entity\DigitalPost;
 use App\Entity\DigitalPost\Recipient as DigitalPostRecipient;
+use App\Entity\DigitalPostAttachment;
 use App\Entity\Document;
 use App\Service\DocumentUploader;
 use ItkDev\Serviceplatformen\Service\SF1601\Serializer;
@@ -62,6 +63,7 @@ class ForsendelseHelper
             $document = $attachment->getDocument();
 
             $bilag = (new Bilag())
+                ->setBilagNavn($this->getBilagNavn($attachment))
                 ->setFilformatNavn('PDF')
                 ->setVedhaeftningIndholdData($this->documentUploader->getFileContent($document))
             ;
@@ -69,6 +71,21 @@ class ForsendelseHelper
         }
 
         return $forsendelse;
+    }
+
+    /**
+     * "Navnet skal være mellem 1 og 1024 tegn, og må ikke slutte med . eller indeholde specialtegn.".
+     */
+    private function getBilagNavn(DigitalPostAttachment $attachment): string
+    {
+        $document = $attachment->getDocument();
+
+        $navn = $document->getFilename() ?? sprintf('Bilag %d', $attachment->getPosition());
+        $navn = preg_replace('/[^\w-]/', '', $navn);
+        $navn = rtrim($navn, '.');
+        $navn = substr($navn, 0, 1024);
+
+        return $navn;
     }
 
     public function removeDocumentContent(ForsendelseI $forsendelse): ForsendelseI


### PR DESCRIPTION
https://jira.itkdev.dk/browse/TVIST1-809

- 🐛 fix(DigitalPoster.php): fix null pointer exception when forsendelse is null The code now checks if the forsendelse variable is null before setting the forsendelse and forsendelseUuid properties of the envelope object. This prevents a null pointer exception that would occur when the forsendelse variable is null.
- 🔨 refactor(DigitalPostEnvelope.php): add errors property and methods to handle errors 🔨 refactor(SF1601/DigitalPoster.php): add error to DigitalPostEnvelope when sending digital post fails The DigitalPostEnvelope entity now has an errors property that is used to store errors that occur when sending a digital post. The addError method is used to add an error to the errors property. The getErrors method is used to retrieve the errors property. The SF1601/DigitalPoster.php file has been updated to add an error to the DigitalPostEnvelope when sending a digital post fails. This allows for better error handling and tracking of errors that occur when sending digital posts.
- 🔍 refactor(DigitalPostEnvelopeListCommand.php): add options to show throwable and errors The `DigitalPostEnvelopeListCommand` now has two new options: `--show-throwable` and `--show-errors`. These options allow the user to see the throwable and errors associated with each envelope. The throwable is shown as a var_export of the unserialized throwable, and the errors are shown as a var_export of the errors array. Additionally, the command now supports filtering by envelope id using the `--id` option.
