### PR TITLE
TVIST1-828: Use document on load rather than ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-375](https://github.com/itk-dev/naevnssekretariatet/pull/375)
+  Use document on load rather than ready.
+
 ## [1.5.0] 2023-05-22
 
 - [PR-373](https://github.com/itk-dev/naevnssekretariatet/pull/373)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To get a local copy up and running follow these simple steps.
    docker compose run --rm node yarn dev
    ```
 
-   and to watch for for changes run
+   and to watch for changes run
 
    ```sh
    docker compose run --rm node yarn watch

--- a/assets/app.js
+++ b/assets/app.js
@@ -2,13 +2,11 @@ import './app.scss'
 import * as bootstrap from 'bootstrap'
 import '@popperjs/core'
 import 'bs-custom-file-input'
-import $ from 'jquery'
 import 'select2'
 
 const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
 
 window.addEventListener('load', () => {
-// $(document).ready(() => {
   [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
   window.dispatchEvent(new Event('ajaxload'))
 })

--- a/assets/app.js
+++ b/assets/app.js
@@ -7,7 +7,8 @@ import 'select2'
 
 const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
 
-$(document).ready(() => {
+window.addEventListener('load', () => {
+// $(document).ready(() => {
   [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
   window.dispatchEvent(new Event('ajaxload'))
 })


### PR DESCRIPTION
https://jira.itkdev.dk/browse/TVIST1-828

* Uses document on 'load' rather than 'ready' to void missing elements