### PR TITLE
#1043: Template placeholder convenience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-384](https://github.com/itk-dev/naevnssekretariatet/pull/384)
+  Added template placeholder relation data to recipient
+  prefix when creating hearing briefings.
+
 ## [1.5.3] - 2023-12-19
 
 - [PR-377](https://github.com/itk-dev/naevnssekretariatet/pull/377)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+## [1.5.4] - 2024-04-03
+
 - [PR-384](https://github.com/itk-dev/naevnssekretariatet/pull/384)
   Added template placeholder relation data to recipient
   prefix when creating hearing briefings.
@@ -302,7 +304,8 @@ Fixed error in unescaped characters in filename
 - [TVIST1-604](https://jira.itkdev.dk/browse/TVIST1-604):
   Resolved issue regarding time formats.
 
-[Unreleased]: https://github.com/itk-dev/naevnssekretariatet/compare/1.5.3...HEAD
+[Unreleased]: https://github.com/itk-dev/naevnssekretariatet/compare/1.5.4...HEAD
+[1.5.4]: https://github.com/itk-dev/naevnssekretariatet/compare/1.5.3...1.5.4
 [1.5.3]: https://github.com/itk-dev/naevnssekretariatet/compare/1.5.2...1.5.3
 [1.5.2]: https://github.com/itk-dev/naevnssekretariatet/compare/1.5.1...1.5.2
 [1.5.1]: https://github.com/itk-dev/naevnssekretariatet/compare/1.5.0...1.5.1

--- a/src/Service/MailTemplateHelper.php
+++ b/src/Service/MailTemplateHelper.php
@@ -377,6 +377,9 @@ class MailTemplateHelper
                 $relationData = json_decode($this->serializer->serialize($relation, 'json', ['groups' => ['mail_template']]), true);
 
                 $data += ['relation' => $relationData];
+
+                // For convenience, we add the same relation data with relevant prefix to help users.
+                $data['recipient'] += $relationData;
             } elseif ($entity instanceof AgendaBroadcast) {
                 $data += json_decode($this->serializer->serialize($entity->getAgenda(), 'json', ['groups' => ['mail_template']]), true);
             }


### PR DESCRIPTION
https://leantime.itkdev.dk/tickets/showKanban#/tickets/showTicket/1043

Previously, we made it more convenient for users by adding relation data with the 'recipient' prefix. This was not done with hearing briefings (https://github.com/itk-dev/naevnssekretariatet/blob/develop/src/Service/MailTemplateHelper.php#L350-L351)

* Added above mentioned convenience when creating hearing briefings.

**Note:** Test fails due to https://github.com/symfony/symfony/issues/52844 which has been fixed by updating dependencies in develop by https://github.com/itk-dev/naevnssekretariatet/commit/28f88c78e6bbca89e58dd85c6b5dd3c47a5ee5a3, which is yet to be released.