### PR TITLE
Prepare release 1.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+## [1.5.5] - XXXX
+
 ## [1.5.4] - 2024-04-03
 
 - [PR-384](https://github.com/itk-dev/naevnssekretariatet/pull/384)
@@ -304,7 +306,8 @@ Fixed error in unescaped characters in filename
 - [TVIST1-604](https://jira.itkdev.dk/browse/TVIST1-604):
   Resolved issue regarding time formats.
 
-[Unreleased]: https://github.com/itk-dev/naevnssekretariatet/compare/1.5.4...HEAD
+[Unreleased]: https://github.com/itk-dev/naevnssekretariatet/compare/1.5.5...HEAD
+[1.5.5]: https://github.com/itk-dev/naevnssekretariatet/compare/1.5.4...1.5.5
 [1.5.4]: https://github.com/itk-dev/naevnssekretariatet/compare/1.5.3...1.5.4
 [1.5.3]: https://github.com/itk-dev/naevnssekretariatet/compare/1.5.2...1.5.3
 [1.5.2]: https://github.com/itk-dev/naevnssekretariatet/compare/1.5.1...1.5.2


### PR DESCRIPTION
Release 1.5.5

**Note**: Test fails due to https://github.com/symfony/symfony/issues/52844 which has been fixed by updating dependencies in develop by https://github.com/itk-dev/naevnssekretariatet/commit/28f88c78e6bbca89e58dd85c6b5dd3c47a5ee5a3, which is yet to be released.