### PR TITLE
#1232: Fixed BoardRoleCrud search property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ about writing changes to this log.
 
 ## [1.5.5] - XXXX
 
+- [PR-389](https://github.com/itk-dev/naevnssekretariatet/pull/389)
+  Fixed `BoardRole` crud search property.
+
 ## [1.5.4] - 2024-04-03
 
 - [PR-384](https://github.com/itk-dev/naevnssekretariatet/pull/384)

--- a/src/Controller/Admin/BoardRoleCrudController.php
+++ b/src/Controller/Admin/BoardRoleCrudController.php
@@ -28,7 +28,7 @@ class BoardRoleCrudController extends AbstractCrudController
             ->setPageTitle('new', 'Add board role')
             ->setEntityLabelInSingular('Board role')
             ->setEntityLabelInPlural('Board roles')
-            ->setSearchFields(['board'])
+            ->setSearchFields(['board.name', 'title'])
             ->setDefaultSort(['board' => 'ASC'])
             ;
     }


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/1232

* Fixes BoardRole crud search property

**Note**: Test fails due to https://github.com/symfony/symfony/issues/52844 which has been fixed by updating dependencies in develop by https://github.com/itk-dev/naevnssekretariatet/commit/28f88c78e6bbca89e58dd85c6b5dd3c47a5ee5a3, which is yet to be released.