### PR TITLE
1479: Filter out finished cases when creating agenda case items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-396](https://github.com/itk-dev/naevnssekretariatet/pull/396)
+  Filtered out finished cases when creating agenda case items.
+
 ## [1.5.5]
 
 - [PR-394](https://github.com/itk-dev/naevnssekretariatet/pull/394)

--- a/src/Repository/CaseEntityRepository.php
+++ b/src/Repository/CaseEntityRepository.php
@@ -46,11 +46,17 @@ class CaseEntityRepository extends ServiceEntityRepository
 
         $qb = $this->createQueryBuilder('c');
 
+        // We filter out finished cases, i.e. with last status in board.
+        $statuses = explode(PHP_EOL, $board->getStatuses());
+        $endStatus = end($statuses);
+
         $qb->select('c')
             ->where('c.board = :board')
             ->setParameter('board', $board->getId()->toBinary())
             ->andWhere('c.isReadyForAgenda = :isReadyForAgendaCheck')
             ->setParameter('isReadyForAgendaCheck', true)
+            ->andWhere('c.currentPlace != :end_status')
+            ->setParameter('end_status', $endStatus)
         ;
 
         // If $binaryIdsOfActiveCases array is empty NOT IN does not behave as expected


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/1479

* Filters out finished cases (i.e. cases with last board status) during agenda case item creation.