### PR TITLE
1826: Upgrade linuxserver/libreoffice

### DIFF
--- a/.docker/libreoffice-api/Dockerfile
+++ b/.docker/libreoffice-api/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/r/linuxserver/libreoffice
-FROM linuxserver/libreoffice:7.2.2
+FROM linuxserver/libreoffice:7.6.7
 
 # https://github.com/unoconv/unoconv#installing-unoconv
 # RUN apk add --update --no-cache unoconv npm
@@ -11,9 +11,13 @@ ENV UNO_URL https://raw.githubusercontent.com/dagwieers/unoconv/master/unoconv
 RUN apk add --update --no-cache npm msttcorefonts-installer fontconfig \
     && wget $UNO_URL -O /usr/local/bin/unoconv \
     && chmod +x /usr/local/bin/unoconv \
-    && ln -s /usr/bin/python3 /usr/bin/python \
     && update-ms-fonts \
     && fc-cache -f
+
+# TODO: Install distutils via setuptools
+# linuxserver/libreoffice:7.6.7 comes with python 3.12
+# which does not come with distutils
+# cf. https://docs.python.org/3/whatsnew/3.12.html
 
 # Unoconv is deprecated (cf.
 # https://github.com/unoconv/unoconv#unoconv-is-deprecated), but works great. In


### PR DESCRIPTION
https://leantime.itkdev.dk/dashboard/home#/tickets/showTicket/1826

* Upgrading libreoffice

**Note:** 
`linuxserver/libreoffice:7.6.7` comes with

* `python` -> `python3` symlink
* `python:3.12`

`python3.12` has removed the `distutils` module package  (cf. https://docs.python.org/3/whatsnew/3.12.html)

This now gives the https://github.com/unoconv/unoconv/issues/591 issue.